### PR TITLE
Updated funnelback-php to use Guzzle 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "guzzlehttp/guzzle": "~5.0"
+    "guzzlehttp/guzzle": "~6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"

--- a/src/Funnelback/ClientInterface.php
+++ b/src/Funnelback/ClientInterface.php
@@ -27,12 +27,12 @@ interface ClientInterface {
   public function getClient();
 
   /**
-   * Returns the base url.
+   * Returns the base uri.
    *
    * @return string
-   *   The base url.
+   *   The base uri.
    */
-  public function getBaseUrl();
+  public function getBaseUri();
 
   /**
    * Returns the sub-path.

--- a/src/Funnelback/Facet.php
+++ b/src/Funnelback/Facet.php
@@ -41,8 +41,8 @@ class Facet {
    */
   public function __construct($facet_data) {
     $this->facetData = $facet_data;
-    $this->name = $facet_data['name'];
-    $this->facetItems = $this->buildFacetItems($facet_data['categories'][0]['values']);
+    $this->name = $facet_data->name;
+    $this->facetItems = $this->buildFacetItems($facet_data->categories[0]->values);
   }
 
   /**

--- a/src/Funnelback/FacetItem.php
+++ b/src/Funnelback/FacetItem.php
@@ -48,9 +48,9 @@ class FacetItem {
    */
   public function __construct($facet_item_data) {
     $this->facetItemData = $facet_item_data;
-    $this->label = $facet_item_data['label'];
-    $this->count = $facet_item_data['count'];
-    $this->queryStringParam = $facet_item_data['queryStringParam'];
+    $this->label = $facet_item_data->label;
+    $this->count = $facet_item_data->count;
+    $this->queryStringParam = $facet_item_data->queryStringParam;
   }
 
   /**

--- a/src/Funnelback/Response.php
+++ b/src/Funnelback/Response.php
@@ -6,7 +6,7 @@
  */
 
 namespace Funnelback;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * The Funnelback search response.
@@ -79,20 +79,20 @@ class Response {
   /**
    * Creates a new Funnelback response.
    *
-   * @param \GuzzleHttp\Message\ResponseInterface $http_response
+   * @param Psr\Http\Message\ResponseInterface $http_response
    *   The http response.
    */
   public function __construct(ResponseInterface $http_response) {
     $this->httpResponse = $http_response;
-    $this->responseJson = $http_response->json();
-    $this->query = $this->responseJson['question']['query'];
-    $response = $this->responseJson['response'];
-    $this->returnCode = $response['returnCode'];
-    $this->totalTimeMillis = $response['performanceMetrics']['totalTimeMillis'];
-    $result_packet = $response['resultPacket'];
-    $this->resultsSummary = new ResultSummary($result_packet['resultsSummary']);
-    $this->results = $this->buildResults($result_packet['results']);
-    $this->facets = $this->buildFacets($response['facets']);
+    $this->responseJson = json_decode($http_response->getBody()->getContents());
+    $this->query = $this->responseJson->question->query;
+    $response = $this->responseJson->response;
+    $this->returnCode = $this->httpResponse->getStatusCode();
+    $this->totalTimeMillis = $response->performanceMetrics->totalTimeMillis;
+    $result_packet = $response->resultPacket;
+    $this->resultsSummary = new ResultSummary($result_packet->resultsSummary);
+    $this->results = $this->buildResults($result_packet->results);
+    $this->facets = $this->buildFacets($response->facets);
   }
 
   /**

--- a/src/Funnelback/Result.php
+++ b/src/Funnelback/Result.php
@@ -68,15 +68,15 @@ class Result {
    *   The raw result data.
    */
   public function __construct($result_data) {
-    $this->cacheUrl = $result_data['cacheUrl'];
-    $this->clickUrl = $result_data['clickTrackingUrl'];
+    $this->cacheUrl = $result_data->cacheUrl;
+    $this->clickUrl = $result_data->clickTrackingUrl;
     $date = new \DateTime('now', new \DateTimeZone("UTC"));
     // Remove milliseconds.
-    $date->setTimestamp($result_data['date'] / 1000);
+    $date->setTimestamp($result_data->date / 1000);
     $this->date = $date;
-    $this->liveUrl = $result_data['liveUrl'];
-    $this->summary = $result_data['summary'];
-    $this->title = $result_data['title'];
+    $this->liveUrl = $result_data->liveUrl;
+    $this->summary = $result_data->summary;
+    $this->title = $result_data->title;
     $this->resultData = $result_data;
   }
 

--- a/src/Funnelback/ResultSummary.php
+++ b/src/Funnelback/ResultSummary.php
@@ -36,7 +36,7 @@ class ResultSummary {
    *   The start index.
    */
   public function getStart() {
-    return $this->summaryData['currStart'];
+    return $this->summaryData->currStart;
   }
 
   /**
@@ -46,7 +46,7 @@ class ResultSummary {
    *   The end index.
    */
   public function getEnd() {
-    return $this->summaryData['currEnd'];
+    return $this->summaryData->currEnd;
   }
 
   /**
@@ -56,7 +56,7 @@ class ResultSummary {
    *   The page size.
    */
   public function getPageSize() {
-    return $this->summaryData['numRanks'];
+    return $this->summaryData->numRanks;
   }
 
   /**
@@ -66,7 +66,7 @@ class ResultSummary {
    *   The total result count.
    */
   public function getTotal() {
-    return $this->summaryData['totalMatching'];
+    return $this->summaryData->totalMatching;
   }
 
   /**


### PR DESCRIPTION
Hi Kim,

A bit of preliminary work ahead of adding support for push.
- Bumped Guzzle to 6.
- Added support for passing in a Guzzle Handler into the Client - http://docs.guzzlephp.org/en/latest/handlers-and-middleware.html (used in ClientTest.php)
- Test changed to Funnelback\Client instead of GuzzleHttp\Client.
